### PR TITLE
[#48058] GH Actions: Switched to using the Debian container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,23 +7,28 @@ on:
         branches: [main]
 
 jobs:
-    readme-tests:
+    cancel-previous-job:
         runs-on: ubuntu-latest
         steps:
             - name: Cancel previous
               uses: styfle/cancel-workflow-action@0.11.0
               with:
                   access_token: ${{ github.token }}
+    readme-tests:
+        runs-on: ubuntu-latest
+        container:
+            image: debian:bullseye
+        steps:
+            - name: Install tuttest dependencies
+              run: |
+                  apt-get update -qqy
+                  apt-get install -qqy --no-install-recommends python3 python3-pip git git-lfs colorized-logs sudo
+                  pip3 install git+https://github.com/antmicro/tuttest.git
             - name: Checkout sources
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   submodules: 'recursive'
                   lfs: true
-            - name: Install tuttest dependencies
-              run: |
-                  sudo apt-get update -qqy
-                  sudo apt-get install -qqy --no-install-recommends python3 python3-pip git colorized-logs
-                  sudo pip3 install git+https://github.com/antmicro/tuttest.git
             - name: Run README.md snippets
               run: |
                   ./.github/scripts/readme-tests.sh

--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ In Debian-based distros they can be installed with:
 ```bash
 sudo apt-get update
 sudo apt-get install -qqy --no-install-recommends \
+    ca-certificates \
     cmake \
+    curl \
+    fonts-lato \
     g++ \
     git \
     git-lfs \
@@ -129,13 +132,14 @@ To create a virtual environment run the following commands:
 ```bash
 python3 -m venv venv                       # create venv
 source ./venv/bin/activate                 # activate it
-python3 -m pip install -r requirements.txt # install dependencies
+python3 -m pip install --upgrade pip       # install dependencies
+python3 -m pip install -r requirements.txt
 ```
 
 To install additional python packages required to run Kenning compilation, inference and report rendering, run the following command:
 
 ```bash
-python3 -m pip install third-party/kenning[tensorflow,reports,uart,renode,object_detection]
+python3 -m pip install third-party/kenning[tensorflow,reports,uart,renode]
 ```
 
 For installing IREE Python modules for compiling models in Kenning, either follow [Building IREE from source](https://openxla.github.io/iree/building-from-source/#reference-pages) instructions to build Python bindings from `third-party/iree-rv32-springbok/third_party/iree/` directory, or install the available Python modules using `pip`:
@@ -299,7 +303,7 @@ To evaluate the model, run:
 ```bash
 kenning optimize test \
     --json-cfg kenning-scenarios/renode-magic-wand-iree-bare-metal-inference.json \
-    --measurements ./results.json
+    --measurements ./results.json --verbosity INFO
 ```
 
 To render the report with performance and quality metrics (including Renode performance metrics), run:
@@ -355,7 +359,7 @@ In `runtime`, the default `IREERuntime` block is used to mark that IREE is used 
 ```
 kenning optimize test \
     --json-cfg third-party/kenning/scripts/jsonconfigs/iree-bare-metal-inference.json \
-    --measurements ./results.json
+    --measurements ./results.json --verbosity INFO
 ```
 
 This flow, however, won't collect inference information necessary to plot the performance metrics collected during Renode simulation.


### PR DESCRIPTION
The base image for GHA provides mono library that fails during pyrenode3 runtime. This PR changes the default image.